### PR TITLE
Add calling feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # disc-bot
 ## A high performance bot written in Rust
 The goal is to replace some popular poorly designed bots with a all in one solution that is self hostable. This project is in early stages and features have not been planned yet.
+
+## Developers
+The current developers are: neeleshpoli (wesellinsurance), foreskin (disguisedfox)
 ## Contributions
 We welcome contributions! Any performance improvements, even if small, are always welcome :)

--- a/src/calling/mod.rs
+++ b/src/calling/mod.rs
@@ -1,42 +1,182 @@
 use std::collections::HashMap;
 
+use poise::serenity_prelude as serenity;
+
+use crate::{Context, Error};
+
 pub struct Calling {
-    waiting_server: Option<u64>,
-    current_conversations: HashMap<u64, u64>
+    // The key is the channel id of channel, the value is the guild id (to make sure that the same server isn't paired togther if the same command is ran in a different channel)
+    waiting_servers: HashMap<u64, u64>,
+    current_conversations: HashMap<u64, u64>,
 }
 
 impl Calling {
     pub async fn new() -> Self {
         Self {
-            waiting_server: None,
-            current_conversations: HashMap::new()
+            waiting_servers: HashMap::new(),
+            current_conversations: HashMap::new(),
         }
     }
 
-    pub async fn add_to_queue(&mut self, channel_id: u64) -> Result<(), ()> {
-        if self.channel_in_queue(&channel_id).await {
+    pub async fn add_to_queue(
+        &mut self,
+        channel_id: u64,
+        guild_id: u64,
+        ctx: &Context<'_>,
+    ) -> Result<(), ()> {
+        if self.contains_channel(&channel_id).await {
             return Err(());
-        } else if self.waiting_server.is_some() {
-            tokio::task::block_in_place(|| {
-                self.current_conversations.insert(channel_id.to_owned(), self.waiting_server.as_ref().unwrap().to_owned());
-                self.current_conversations.insert(self.waiting_server.as_ref().unwrap().to_owned(), channel_id);
-            });
         } else {
-            self.waiting_server = Some(channel_id);
+            let mut found_channel_id: Option<u64> = None;
+            for (key, value) in self.waiting_servers.iter().clone() {
+                if value == &guild_id {
+                    continue;
+                }
+
+                found_channel_id = Some(*key);
+                self.current_conversations.insert(*key, channel_id);
+                self.current_conversations.insert(channel_id, *key);
+                break;
+            }
+
+            if found_channel_id.is_some() {
+                self.waiting_servers
+                    .remove_entry(&found_channel_id.unwrap());
+                // Send a message to both channels to let them know that the call is ready
+                ctx.say("Call ready! Beware of people trying to scam! They might go as far as being friends with you only to scam you later.").await.expect("Error sending message");
+
+                let channel = serenity::model::id::ChannelId(
+                    self.retrieve_channel_id(&channel_id)
+                        .await
+                        .unwrap()
+                        .to_owned(),
+                );
+                channel.say(&ctx.http(), "Call ready! Beware of people trying to scam! They might go as far as being friends with you only to scam you later.").await.expect("Error sending message");
+            } else {
+                self.waiting_servers.insert(channel_id, guild_id);
+            }
         }
         Ok(())
     }
 
-    pub async fn channel_in_queue(&self, &channel_id: &u64) -> bool {
-        tokio::task::block_in_place(|| {
-            self.current_conversations.contains_key(&channel_id)
-        })
+    pub async fn channel_in_convo(&self, &channel_id: &u64) -> bool {
+        self.current_conversations.contains_key(&channel_id)
     }
 
-
-    pub async fn retrieve_channel_id(&self, channel_id: &u64) -> Option<u64> {
-        tokio::task::block_in_place(|| {
-            self.current_conversations.get(&channel_id)
-        }).copied()
+    pub async fn contains_channel(&self, &channel_id: &u64) -> bool {
+        self.waiting_servers.contains_key(&channel_id)
+            || self.current_conversations.contains_key(&channel_id)
     }
+
+    pub async fn retrieve_channel_id(&self, channel_id: &u64) -> Option<&u64> {
+        self.current_conversations.get(&channel_id)
+    }
+
+    pub async fn remove_channel(
+        &mut self,
+        channel_id: &u64,
+        ctx: &Context<'_>,
+    ) -> Result<(), Error> {
+        match self.current_conversations.remove(channel_id) {
+            Some(id) => {
+                self.current_conversations.remove(&id);
+                ctx.say("Ended Conversation!").await?;
+
+                let channel = serenity::model::id::ChannelId(
+                    id
+                );
+                channel.say(&ctx.http(), "Ended Conversation!").await?;
+
+                Ok(())
+            }
+            None => match self.waiting_servers.remove(channel_id) {
+                Some(_) => {
+                    ctx.say("Removed from queue!").await?;
+                    Ok(())
+                }
+                None => {
+                    ctx.say("This channel is not in the queue or in a conversation!")
+                        .await?;
+                    Ok(())
+                }
+            },
+        }
+    }
+}
+
+/// Call other users on different servers
+///
+/// Running this command will place you into a queue and if ideal server is found, it enter a call
+#[poise::command(slash_command, subcommands("join", "exit"))]
+pub async fn call(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+pub async fn join(ctx: Context<'_>) -> Result<(), Error> {
+    let mut calling = ctx.data().calling.write().await;
+    match calling
+        .add_to_queue(ctx.channel_id().0, ctx.guild_id().unwrap().0, &ctx)
+        .await
+    {
+        Ok(_) => {}
+        Err(_) => {
+            ctx.say("This channel is alredy in the queue or in a conversation!")
+                .await?;
+            return Ok(());
+        }
+    }
+
+    // Create a button that allows the user to leave the queue
+    // let exit_queue_button = serenity::CreateButton::default()
+    //     .label("Exit Queue")
+    //     .style(serenity::ButtonStyle::Danger)
+    //     .custom_id("exit_queue")
+    //     .to_owned();
+
+    // let action_row = serenity::CreateActionRow::default().add_button(exit_queue_button).to_owned();
+
+    let m = ctx
+        .send(
+            |m| m.content("Added to queue!"), // .components(|c| c.add_action_row(action_row))
+        )
+        .await?;
+
+    // let interaction = m
+    //     .message()
+    //     .await?
+    //     .await_component_interaction(ctx)
+    //     .timeout(std::time::Duration::from_secs(60))
+    //     .author_id(ctx.author().id)
+    //     .await
+    //     .unwrap();
+
+    // let exit_queue_button = serenity::CreateButton::default()
+    //     .label("Exit Queue")
+    //     .style(serenity::ButtonStyle::Danger)
+    //     .custom_id("exit_queue")
+    //     .disabled(true)
+    //     .to_owned();
+
+    // let action_row = serenity::CreateActionRow::default().add_button(exit_queue_button).to_owned();
+
+    // m.edit(ctx, |b| {
+    //     b.components(|b| b)
+    //         .content("Removed from queue!")
+    //         .components(|c| c.add_action_row(action_row))
+    // }).await?;
+
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+pub async fn exit(ctx: Context<'_>) -> Result<(), Error> {
+    ctx.data()
+        .calling
+        .write()
+        .await
+        .remove_channel(&ctx.channel_id().0, &ctx)
+        .await
+        .unwrap();
+    Ok(())
 }

--- a/src/calling/mod.rs
+++ b/src/calling/mod.rs
@@ -1,13 +1,19 @@
 use std::collections::HashMap;
 
-use poise::serenity_prelude as serenity;
+use poise::serenity_prelude::{ChannelId, GuildId};
 
-use crate::{Context, Error};
+use crate::{error::Error, BotResult, Context};
 
 pub struct Calling {
-    // The key is the channel id of channel, the value is the guild id (to make sure that the same server isn't paired togther if the same command is ran in a different channel)
-    waiting_servers: HashMap<u64, u64>,
-    current_conversations: HashMap<u64, u64>,
+    waiting_servers: HashMap<ChannelId, GuildId>,
+    current_conversations: HashMap<ChannelId, ChannelId>,
+}
+
+enum CallingStatus {
+    WaitingInCall,
+    AddedToCall(ChannelId),
+    RemovedFromQueue,
+    EndedCall(ChannelId),
 }
 
 impl Calling {
@@ -18,16 +24,15 @@ impl Calling {
         }
     }
 
-    pub async fn add_to_queue(
+    async fn add_to_queue(
         &mut self,
-        channel_id: u64,
-        guild_id: u64,
-        ctx: &Context<'_>,
-    ) -> Result<(), ()> {
+        channel_id: ChannelId,
+        guild_id: GuildId,
+    ) -> BotResult<CallingStatus> {
         if self.contains_channel(&channel_id).await {
-            return Err(());
+            return Err(crate::error::Error::ChannelInQueue);
         } else {
-            let mut found_channel_id: Option<u64> = None;
+            let mut found_channel_id: Option<ChannelId> = None;
             for (key, value) in self.waiting_servers.iter().clone() {
                 if value == &guild_id {
                     continue;
@@ -39,66 +44,39 @@ impl Calling {
                 break;
             }
 
-            if found_channel_id.is_some() {
-                self.waiting_servers
-                    .remove_entry(&found_channel_id.unwrap());
-                // Send a message to both channels to let them know that the call is ready
-                ctx.say("Call ready! Beware of people trying to scam! They might go as far as being friends with you only to scam you later.").await.expect("Error sending message");
+            if let Some(channel_id) = found_channel_id {
+                self.waiting_servers.remove_entry(&channel_id);
 
-                let channel = serenity::model::id::ChannelId(
-                    self.retrieve_channel_id(&channel_id)
-                        .await
-                        .unwrap()
-                        .to_owned(),
-                );
-                channel.say(&ctx.http(), "Call ready! Beware of people trying to scam! They might go as far as being friends with you only to scam you later.").await.expect("Error sending message");
+                return Ok(CallingStatus::AddedToCall(channel_id));
             } else {
                 self.waiting_servers.insert(channel_id, guild_id);
+                Ok(CallingStatus::WaitingInCall)
             }
         }
-        Ok(())
     }
 
-    pub async fn channel_in_convo(&self, &channel_id: &u64) -> bool {
+    pub async fn channel_in_convo(&self, &channel_id: &ChannelId) -> bool {
         self.current_conversations.contains_key(&channel_id)
     }
 
-    pub async fn contains_channel(&self, &channel_id: &u64) -> bool {
+    async fn contains_channel(&self, &channel_id: &ChannelId) -> bool {
         self.waiting_servers.contains_key(&channel_id)
             || self.current_conversations.contains_key(&channel_id)
     }
 
-    pub async fn retrieve_channel_id(&self, channel_id: &u64) -> Option<&u64> {
+    pub async fn retrieve_channel_id(&self, channel_id: &ChannelId) -> Option<&ChannelId> {
         self.current_conversations.get(&channel_id)
     }
 
-    pub async fn remove_channel(
-        &mut self,
-        channel_id: &u64,
-        ctx: &Context<'_>,
-    ) -> Result<(), Error> {
-        match self.current_conversations.remove(channel_id) {
+    async fn remove_channel(&mut self, channel_id: &ChannelId) -> BotResult<CallingStatus> {
+        match self.current_conversations.remove(&channel_id) {
             Some(id) => {
                 self.current_conversations.remove(&id);
-                ctx.say("Ended Conversation!").await?;
-
-                let channel = serenity::model::id::ChannelId(
-                    id
-                );
-                channel.say(&ctx.http(), "Ended Conversation!").await?;
-
-                Ok(())
+                Ok(CallingStatus::EndedCall(id))
             }
             None => match self.waiting_servers.remove(channel_id) {
-                Some(_) => {
-                    ctx.say("Removed from queue!").await?;
-                    Ok(())
-                }
-                None => {
-                    ctx.say("This channel is not in the queue or in a conversation!")
-                        .await?;
-                    Ok(())
-                }
+                Some(_) => Ok(CallingStatus::RemovedFromQueue),
+                None => Err(Error::ChannelNotInQueue),
             },
         }
     }
@@ -108,18 +86,38 @@ impl Calling {
 ///
 /// Running this command will place you into a queue and if ideal server is found, it enter a call
 #[poise::command(slash_command, subcommands("join", "exit"))]
-pub async fn call(_ctx: Context<'_>) -> Result<(), Error> {
+pub async fn call(_ctx: Context<'_>) -> BotResult<()> {
     Ok(())
 }
 
 #[poise::command(slash_command)]
-pub async fn join(ctx: Context<'_>) -> Result<(), Error> {
+pub async fn join(ctx: Context<'_>) -> BotResult<()> {
     let mut calling = ctx.data().calling.write().await;
     match calling
-        .add_to_queue(ctx.channel_id().0, ctx.guild_id().unwrap().0, &ctx)
+        .add_to_queue(
+            ctx.channel_id(),
+            match ctx.guild_id() {
+                Some(guild) => guild,
+                None => {
+                    ctx.say("You must use this command in a server!").await?;
+                    return Ok(());
+                }
+            },
+        )
         .await
     {
-        Ok(_) => {}
+        Ok(status) => match status {
+            CallingStatus::WaitingInCall => {
+                ctx.say("Added to queue!").await.unwrap();
+            }
+            CallingStatus::AddedToCall(other_channel) => {
+                let message = String::from("Call ready! Beware of people trying to scam! They might go as far as being friends with you only to scam you later.");
+
+                ctx.say(&message).await.unwrap();
+                other_channel.say(&ctx.http(), &message).await.unwrap();
+            }
+            _ => todo!(),
+        },
         Err(_) => {
             ctx.say("This channel is alredy in the queue or in a conversation!")
                 .await?;
@@ -127,56 +125,33 @@ pub async fn join(ctx: Context<'_>) -> Result<(), Error> {
         }
     }
 
-    // Create a button that allows the user to leave the queue
-    // let exit_queue_button = serenity::CreateButton::default()
-    //     .label("Exit Queue")
-    //     .style(serenity::ButtonStyle::Danger)
-    //     .custom_id("exit_queue")
-    //     .to_owned();
-
-    // let action_row = serenity::CreateActionRow::default().add_button(exit_queue_button).to_owned();
-
-    let m = ctx
-        .send(
-            |m| m.content("Added to queue!"), // .components(|c| c.add_action_row(action_row))
-        )
-        .await?;
-
-    // let interaction = m
-    //     .message()
-    //     .await?
-    //     .await_component_interaction(ctx)
-    //     .timeout(std::time::Duration::from_secs(60))
-    //     .author_id(ctx.author().id)
-    //     .await
-    //     .unwrap();
-
-    // let exit_queue_button = serenity::CreateButton::default()
-    //     .label("Exit Queue")
-    //     .style(serenity::ButtonStyle::Danger)
-    //     .custom_id("exit_queue")
-    //     .disabled(true)
-    //     .to_owned();
-
-    // let action_row = serenity::CreateActionRow::default().add_button(exit_queue_button).to_owned();
-
-    // m.edit(ctx, |b| {
-    //     b.components(|b| b)
-    //         .content("Removed from queue!")
-    //         .components(|c| c.add_action_row(action_row))
-    // }).await?;
-
     Ok(())
 }
 
+/// End the call if you are in one, or exit the queue
 #[poise::command(slash_command)]
-pub async fn exit(ctx: Context<'_>) -> Result<(), Error> {
-    ctx.data()
+pub async fn exit(ctx: Context<'_>) -> BotResult<()> {
+    match ctx
+        .data()
         .calling
         .write()
         .await
-        .remove_channel(&ctx.channel_id().0, &ctx)
+        .remove_channel(&ctx.channel_id())
         .await
-        .unwrap();
+    {
+        Ok(channel_id) => match channel_id {
+            CallingStatus::EndedCall(other_channel) => {
+                ctx.say("Ended call!").await?;
+                other_channel
+                    .say(&ctx.http(), "The other server ended the call!")
+                    .await?;
+            }
+            _ => todo!(),
+        },
+        Err(_) => {
+            ctx.say("This channel is not in the queue or conversation!")
+                .await?;
+        }
+    }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,19 @@
-use std::{sync::Arc, fs, io::{Write, Read}};
+use std::{
+    fs,
+    io::{Read, Write},
+    sync::Arc,
+};
 
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
-lazy_static!(
+lazy_static! {
     pub static ref CONFIG: Arc<Config> = Arc::new(Config::new());
-);
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
-    pub token: String
+    pub token: String,
 }
 
 impl Config {
@@ -23,13 +27,14 @@ impl Config {
         let mut contents = String::new();
         config_file.read_to_string(&mut contents).unwrap();
 
-
         if contents.is_empty() {
             let default_config = Config {
-                token: String::from("insert_token_here")
+                token: String::from("insert_token_here"),
             };
 
-            config_file.write_all(toml::to_string_pretty(&default_config).unwrap().as_bytes()).unwrap();
+            config_file
+                .write_all(toml::to_string_pretty(&default_config).unwrap().as_bytes())
+                .unwrap();
             panic!("Please fill out the config file and restart the bot");
         }
         toml::from_str(&contents).unwrap()

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ impl Config {
             .write(true)
             .create(true)
             .open("./config.toml")
-            .unwrap();
+            .expect("Error with config file! Cannot create or open the file!");
         let mut contents = String::new();
         config_file.read_to_string(&mut contents).unwrap();
 
@@ -34,7 +34,7 @@ impl Config {
 
             config_file
                 .write_all(toml::to_string_pretty(&default_config).unwrap().as_bytes())
-                .unwrap();
+                .expect("Unable to write default config to file!");
             panic!("Please fill out the config file and restart the bot");
         }
         toml::from_str(&contents).unwrap()

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+
+use poise::serenity_prelude;
+
+type DiscordError = Box<dyn std::error::Error + Send + Sync>;
+
+#[derive(Debug)]
+pub enum Error {
+    ChannelInQueue,
+    ChannelNotInQueue,
+    IOError(std::io::Error),
+    DiscordError(DiscordError),
+}
+
+impl From<DiscordError> for Error {
+    fn from(error: DiscordError) -> Self {
+        Error::DiscordError(error)
+    }
+}
+
+impl From<serenity_prelude::Error> for Error {
+    fn from(error: serenity_prelude::Error) -> Self {
+        Error::DiscordError(Box::new(error))
+    }
+}
+
+// Handles std io errors as well
+impl From<tokio::io::Error> for Error {
+    fn from(error: tokio::io::Error) -> Self {
+        Error::IOError(error)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::DiscordError(error) => error.fmt(f),
+            Error::ChannelInQueue => todo!(),
+            Error::IOError(error) => error.fmt(f),
+            Error::ChannelNotInQueue => todo!(),
+        }
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,37 +5,44 @@ use tokio::{fs, io::AsyncWriteExt, sync::Mutex};
 pub enum LogType {
     Info,
     Warning,
-    Error
+    Error,
 }
 
 // Make the struct for the logger, this keeps the file open and allows us to write to it without reopening it every time
 pub struct Logger {
-    file: Mutex<fs::File>
+    file: Mutex<fs::File>,
 }
 
 // This is the functions for the logger struct
 impl Logger {
     // The new function is similar to the __init__ function in python
     pub async fn new() -> tokio::io::Result<Logger> {
-        Ok(
-            Logger {
-                // Check if the file exists byt getting the metadata of the file. If it doesn't exist, create it
-                file: {
-                    if fs::metadata("./logs/").await.is_err() {
-                        fs::create_dir("./logs/").await?;
-                    }
-    
-                    if fs::metadata("./logs/latest.log").await.is_ok() {
-                        let now = Local::now();
-                        fs::rename("./logs/latest.log", format!("./logs/{}.log", now.format("%Y-%m-%d %H-%M-%S"))).await?;
-                    }
-    
-                    fs::File::create("./logs/latest.log").await?;
-                    // Mutex is used to safly write to the variable across multiple threads
-                    Mutex::new(fs::OpenOptions::new().append(true).open("./logs/latest.log").await?)
+        Ok(Logger {
+            // Check if the file exists byt getting the metadata of the file. If it doesn't exist, create it
+            file: {
+                if fs::metadata("./logs/").await.is_err() {
+                    fs::create_dir("./logs/").await?;
                 }
-            }
-        )
+
+                if fs::metadata("./logs/latest.log").await.is_ok() {
+                    let now = Local::now();
+                    fs::rename(
+                        "./logs/latest.log",
+                        format!("./logs/{}.log", now.format("%Y-%m-%d %H-%M-%S")),
+                    )
+                    .await?;
+                }
+
+                fs::File::create("./logs/latest.log").await?;
+                // Mutex is used to safly write to the variable across multiple threads
+                Mutex::new(
+                    fs::OpenOptions::new()
+                        .append(true)
+                        .open("./logs/latest.log")
+                        .await?,
+                )
+            },
+        })
     }
 
     // The log function is used to write to the file and print the colored output to the console
@@ -44,18 +51,18 @@ impl Logger {
         let log_string: String;
         let mut file_lock = self.file.lock().await;
 
-        // Match 
+        // Match
         match log_type {
             LogType::Info => {
                 log_string = format!("{} [INFO] {}\n", time, message);
                 file_lock.write_all(log_string.as_bytes()).await.unwrap();
                 print!("{}", log_string);
-            },
+            }
             LogType::Warning => {
                 log_string = format!("{} [WARNING] {}\n", time, message);
                 file_lock.write_all(log_string.as_bytes()).await.unwrap();
                 print!("\x1b[33m{}\x1b[0m", log_string);
-            },
+            }
             LogType::Error => {
                 log_string = format!("{} [ERROR] {}\n", time, message);
                 file_lock.write_all(log_string.as_bytes()).await.unwrap();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,40 +1,38 @@
-use chrono::Local;
+use chrono::{DateTime, Local};
 use tokio::{fs, io::AsyncWriteExt, sync::Mutex};
 
-// List all possible log types
+use crate::error::Error;
+
 pub enum LogType {
     Info,
     Warning,
     Error,
 }
 
-// Make the struct for the logger, this keeps the file open and allows us to write to it without reopening it every time
 pub struct Logger {
     file: Mutex<fs::File>,
 }
 
-// This is the functions for the logger struct
 impl Logger {
-    // The new function is similar to the __init__ function in python
     pub async fn new() -> tokio::io::Result<Logger> {
         Ok(Logger {
-            // Check if the file exists byt getting the metadata of the file. If it doesn't exist, create it
             file: {
-                if fs::metadata("./logs/").await.is_err() {
+                if let Err(_) = fs::metadata("./logs/").await {
                     fs::create_dir("./logs/").await?;
                 }
 
-                if fs::metadata("./logs/latest.log").await.is_ok() {
-                    let now = Local::now();
+                if let Ok(metadata) = fs::metadata("./logs/latest.log").await {
                     fs::rename(
                         "./logs/latest.log",
-                        format!("./logs/{}.log", now.format("%Y-%m-%d %H-%M-%S")),
+                        format!("./logs/{}.log", {
+                            let datetime: DateTime<Local> = metadata.created().unwrap().into();
+                            datetime.format("%Y-%m-%d %H-%M-%S").to_string()
+                        }),
                     )
                     .await?;
                 }
 
                 fs::File::create("./logs/latest.log").await?;
-                // Mutex is used to safly write to the variable across multiple threads
                 Mutex::new(
                     fs::OpenOptions::new()
                         .append(true)
@@ -45,8 +43,7 @@ impl Logger {
         })
     }
 
-    // The log function is used to write to the file and print the colored output to the console
-    pub async fn log(&self, log_type: LogType, message: &str) -> Result<(), tokio::io::Error> {
+    pub async fn log(&self, log_type: LogType, message: &str) -> Result<(), Error> {
         let time = Local::now().format("[%Y-%m-%d %H:%M:%S]");
         let log_string: String;
         let mut file_lock = self.file.lock().await;
@@ -70,6 +67,18 @@ impl Logger {
             }
         };
         file_lock.flush().await?;
+        Ok(())
+    }
+
+    pub async fn log_error(&self, error: Error) -> Result<(), Error> {
+        let time = Local::now().format("[%Y-%m-%d %H:%M:%S]");
+        let log_string: String;
+        let mut file_lock = self.file.lock().await;
+
+        log_string = format!("{} [WARNING] {}\n", time, error.to_string());
+        file_lock.write_all(log_string.as_bytes()).await?;
+        print!("\x1b[33m{}\x1b[0m", log_string);
+
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
 mod calling;
 mod config;
+mod error;
 mod logger;
 
+use error::Error;
 use logger::LogType;
 use poise::serenity_prelude as serenity;
 use tokio::sync::{Mutex, RwLock};
 
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Context<'a> = poise::Context<'a, Data, Error>;
+pub type BotResult<T> = Result<T, Error>;
 // Used to store common data across all commands or data the commands might need to access that needs to persist between invocations
+
 pub struct Data {
     logger: Mutex<logger::Logger>,
     calling: RwLock<calling::Calling>,
@@ -43,26 +46,44 @@ async fn event_handler(
                 .await?;
         }
         poise::Event::Message { new_message } => {
-            if new_message.is_own(&ctx.cache) {
+            if new_message.is_own(&ctx.cache) || new_message.webhook_id.is_some() {
                 return Ok(());
             }
-            let channel_id = new_message.channel_id.0;
             let calling = data.calling.read().await;
 
-            if calling.channel_in_convo(&channel_id).await {
-                let channel = serenity::model::id::ChannelId(
-                    calling
-                        .retrieve_channel_id(&channel_id)
-                        .await
-                        .unwrap()
-                        .to_owned(),
-                );
-                channel
-                    .say(
-                        &ctx.http,
-                        format!("{}: {}", new_message.author.name, new_message.content),
-                    )
-                    .await?;
+            if calling.channel_in_convo(&new_message.channel_id).await {
+                let channel = calling
+                    .retrieve_channel_id(&new_message.channel_id)
+                    .await
+                    .unwrap();
+
+                match channel.webhooks(&ctx.http).await {
+                    Ok(webhooks) => {
+                        if webhooks.is_empty() {
+                            channel
+                                .create_webhook(&ctx.http, "Rusty Bot Calling Webhook")
+                                .await
+                                .unwrap();
+                        } else {
+                            for hook in channel.webhooks(&ctx.http).await.unwrap() {
+                                match hook
+                                    .execute(&ctx.http, false, |w| {
+                                        w.content(&new_message.content)
+                                            .avatar_url(new_message.author.avatar_url().unwrap())
+                                            .username(&new_message.author.name)
+                                    })
+                                    .await
+                                {
+                                    Ok(_) => break,
+                                    Err(_) => continue,
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        println!("Err??");
+                    }
+                }
             }
         }
         _ => {}
@@ -74,10 +95,7 @@ async fn event_handler(
 async fn main() {
     let options = poise::FrameworkOptions {
         // Put all commands that need to be registered here
-        commands: vec![
-            ping(),
-            calling::call(),
-        ],
+        commands: vec![ping(), calling::call()],
         prefix_options: poise::PrefixFrameworkOptions {
             prefix: Some("--".to_string()),
             ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,71 +1,27 @@
 mod calling;
-mod logger;
 mod config;
+mod logger;
 
 use logger::LogType;
 use poise::serenity_prelude as serenity;
-use tokio::sync::{RwLock, Mutex};
-// Make custom types that are used, dw too much about this
-type Error = Box<dyn std::error::Error + Send + Sync>;
-type Context<'a> = poise::Context<'a, Data, Error>;
+use tokio::sync::{Mutex, RwLock};
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Context<'a> = poise::Context<'a, Data, Error>;
 // Used to store common data across all commands or data the commands might need to access that needs to persist between invocations
-struct Data {
+pub struct Data {
     logger: Mutex<logger::Logger>,
-    calling: RwLock<calling::Calling>
+    calling: RwLock<calling::Calling>,
 }
 
 /// Respond with pong
 #[poise::command(slash_command, prefix_command)]
-async fn ping(
-    // Use the custom type defined above
-    ctx: Context<'_>,
-) -> Result<(), Error> {
-    ctx.say(format!("Pong! Current latency: {}", ctx.ping().await.as_millis())).await?;
-    Ok(())
-}
-
-// These are docstrings, they are used to describe the command, which shows on discord too
-/// Call a user on a different server!
-#[poise::command(slash_command, prefix_command)]
-async fn call(
-    ctx: Context<'_>,
-) -> Result<(), Error> {
-    let mut calling = ctx.data().calling.write().await;
-    match calling.add_to_queue(ctx.channel_id().0).await {
-        Ok(_) => {},
-        Err(_) => {
-            ctx.say("This channel is alredy in the queue or in a conversation!").await?;
-            return Ok(());
-        }
-    }
-
-    // Create a button that allows the user to leave the queue
-    let exit_queue_button = serenity::CreateButton::default()
-        .label("Exit Queue")
-        .style(serenity::ButtonStyle::Danger)
-        .custom_id("exit_queue")
-        .to_owned();
-    
-    let action_row = serenity::CreateActionRow::default().add_button(exit_queue_button).to_owned();
-    
-
-    let _m = ctx.send(|m| m
-        .content("Added to queue!")
-        // .components(|c| c.add_action_row(action_row))
-    ).await?;
-
-    // let interaction = m
-    //     .message()
-    //     .await?
-    //     .await_component_interaction(ctx)
-    //     .author_id(ctx.author().id)
-    //     .await
-    //     .unwrap();
-
-    // m.edit(ctx, |b| {
-    //     b.components(|b| b).content("Removed from queue!")
-    // }).await?;
-
+async fn ping(ctx: Context<'_>) -> Result<(), Error> {
+    ctx.say(format!(
+        "Pong! Current latency: {}",
+        ctx.ping().await.as_millis()
+    ))
+    .await?;
     Ok(())
 }
 
@@ -73,22 +29,40 @@ async fn event_handler(
     ctx: &serenity::Context,
     event: &poise::Event<'_>,
     _framework: poise::FrameworkContext<'_, Data, Error>,
-    data: &Data
+    data: &Data,
 ) -> Result<(), Error> {
     match event {
         poise::Event::Ready { data_about_bot } => {
-            data.logger.lock().await.log(LogType::Info, &format!("Bot is ready! Logged in as {}!", data_about_bot.user.name)).await?;
-        },
+            data.logger
+                .lock()
+                .await
+                .log(
+                    LogType::Info,
+                    &format!("Bot is ready! Logged in as {}!", data_about_bot.user.name),
+                )
+                .await?;
+        }
         poise::Event::Message { new_message } => {
             if new_message.is_own(&ctx.cache) {
                 return Ok(());
             }
-            let channel_string = new_message.channel_id.0;
+            let channel_id = new_message.channel_id.0;
             let calling = data.calling.read().await;
-            
-            if calling.channel_in_queue(&channel_string).await {
-                let channel = serenity::model::id::ChannelId(calling.retrieve_channel_id(&new_message.channel_id.0).await.unwrap());
-                channel.say(&ctx.http, format!("{}: {}", new_message.author.name, new_message.content)).await?;
+
+            if calling.channel_in_convo(&channel_id).await {
+                let channel = serenity::model::id::ChannelId(
+                    calling
+                        .retrieve_channel_id(&channel_id)
+                        .await
+                        .unwrap()
+                        .to_owned(),
+                );
+                channel
+                    .say(
+                        &ctx.http,
+                        format!("{}: {}", new_message.author.name, new_message.content),
+                    )
+                    .await?;
             }
         }
         _ => {}
@@ -96,49 +70,40 @@ async fn event_handler(
     Ok(())
 }
 
-// Tokio is a async runtime for Rust
 #[tokio::main]
 async fn main() {
     let options = poise::FrameworkOptions {
         // Put all commands that need to be registered here
         commands: vec![
             ping(),
-            call(),
+            calling::call(),
         ],
-        // Prefix here
         prefix_options: poise::PrefixFrameworkOptions {
             prefix: Some("--".to_string()),
-            // Use the defaults for the rest of the struct
             ..Default::default()
         },
         event_handler: |ctx, event, framework, data| {
             Box::pin(event_handler(ctx, event, framework, data))
         },
-        // Use the defaults for the rest of the struct
         ..Default::default()
     };
 
     poise::Framework::builder()
-        // Discord Bot Token
         .token(&config::CONFIG.as_ref().token)
-        // Initilize the data struct to be used when a command is called
         .setup(move |ctx, _ready, framework| {
             Box::pin(async move {
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
                 Ok(Data {
                     logger: Mutex::new(logger::Logger::new().await?),
-                    calling: RwLock::new(calling::Calling::new().await)
+                    calling: RwLock::new(calling::Calling::new().await),
                 })
             })
         })
-        // Load the options here
         .options(options)
-        // Discord intents
-        .intents(serenity::GatewayIntents::non_privileged() | serenity::GatewayIntents::MESSAGE_CONTENT)
-        // Run the bot sharded, check discord api docs for more info
+        .intents(
+            serenity::GatewayIntents::non_privileged() | serenity::GatewayIntents::MESSAGE_CONTENT,
+        )
         .run_autosharded()
-        // Keep the program awaiting here as other it will terminate with the bot running
         .await
-        // Used to get the result value (if its an error or not)
         .unwrap();
 }


### PR DESCRIPTION
Users can run `/call join` to talk with other users in a server. Messages between the servers are sent with webhooks. Channels in the same server cannot be paired together. When the users want to leave, users run `/call exit`. 

Better error handling was implemented and code was cleaned up.